### PR TITLE
Overhaul for molotov

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,18 +46,14 @@ build: $(VENV_PYTHON) install-elcapitan install
 clean-env:
 	@rm -f loadtest.env
 
-
 configure: build
 	@bash loads.tpl
 
-
-#bash -c "source loadtest.env && URL_SERVER=$(URL_SERVER) $(BIN)/ailoads -v -d 30"
-test:
-	bash -c "URL_SERVER=$(URL_SERVER) $(BIN)/ailoads -v -d 30"
+test: build
+	bash -c "URL_SERVER=$(URL_SERVER) $(BIN)/molotov -d 10 -cx loadtest.py"
 
 test-heavy: build
-	bash -c "source loadtest.env && URL_SERVER=$(URL_SERVER) $(BIN)/ailoads -v -d 300 -u 10"
-
+	bash -c "source loadtest.env && URL_SERVER=$(URL_SERVER) $(BIN)/molotov -p 10 -d 300 -cx loadtest.py"
 
 docker-build:
 	docker build -t $(PROJECT) .
@@ -67,7 +63,6 @@ docker-run:
 
 docker-export:
 	docker save "$(PROJECT)/loadtest:latest" | bzip2> "$(PROJECT)-latest.tar.bz2"
-
 
 clean: refresh
 	@rm -fr venv/ __pycache__/ loadtest.env

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ generic load test based on ailoads: https://github.com/loads/ailoads
 
 ## Requirements
 
-- Python 3.4
+- Python 3.5
 
 
 ## How to run the loadtest?

--- a/loadtest.py
+++ b/loadtest.py
@@ -1,15 +1,14 @@
 import os
+import sys; sys.path.append('.')
 
-from ailoads.fmwk import scenario
+import aiohttp
+from molotov import scenario
 
 import utils
 
+
 URL_SERVER = os.getenv('URL_SERVER',
                        'https://antenna.stage.mozaws.net/submit')
-DEBUG = False
-
-if DEBUG:
-    utils._log_everything()
 
 
 # Meomoized generated payloads
@@ -65,6 +64,7 @@ def get_payload_and_headers(size, dump_names=None, compressed=False):
     if compressed:
         payload = utils.compress(payload)
         headers['Content-Encoding'] = 'gzip'
+        headers['Content-Length'] = str(len(payload))
 
     # Make sure the final payload size is correct
     assert len(payload) == size, (
@@ -75,52 +75,49 @@ def get_payload_and_headers(size, dump_names=None, compressed=False):
     return payload, headers
 
 
-def run_test(name, size, dump_names=None, compressed=False):
-    payload, headers = get_payload_and_headers(size, dump_names=dump_names,
-                                               compressed=compressed)
-    resp = utils.post_crash(URL_SERVER, payload, headers)
-
-    print('%s: HTTP %s' % (name, resp.status_code))
-    # Verify HTTP 200
-    resp.raise_for_status()
-    # Verify the response text contains a CrashID
-    utils.verify_crashid(resp.text)
+async def run_test(name, session, size, dump_names=None, compressed=False):
+    payload, headers = get_payload_and_headers(size, dump_names=dump_names, compressed=compressed)
+    async with session.post(URL_SERVER, headers=headers, data=payload,
+                            compress=False, allow_redirects=True) as resp:
+        # Verify HTTP 200
+        assert resp.status == 200
+        # Verify the response text contains a CrashID
+        utils.verify_crashid(await resp.text())
 
 
 @scenario(0)
-def test_crash_100k_compressed():
-    run_test('test_crash_100k_compressed', 100 * 1024, compressed=True)
+async def _test_crash_100k_compressed(session):
+    await run_test('test_crash_100k_compressed', session, 100 * 1024, compressed=True)
 
 
 @scenario(10)
-def test_crash_150k_compressed():
-    run_test('test_crash_150k_compressed', 150 * 1024, compressed=True)
+async def _test_crash_150k_compressed(session):
+    await run_test('test_crash_150k_compressed', session, 150 * 1024, compressed=True)
 
 
-@scenario(85)
-def test_crash_400k_uncompressed():
-    run_test('test_crash_400k_uncompressed', 400 * 1024, compressed=False)
+@scenario(60)
+async def _test_crash_400k_uncompressed(session):
+    await run_test('test_crash_400k_uncompressed', session, 400 * 1024, compressed=False)
 
 
 @scenario(5)
-def test_crash_1_5mb_uncompressed():
-    run_test('test_crash_1_5mb_uncompressed', int(1.5 * 1024 * 1024), compressed=False)
+async def _test_crash_1_5mb_uncompressed(session):
+    await run_test('test_crash_1_5mb_uncompressed', session, int(1.5 * 1024 * 1024), compressed=False)
 
 
 @scenario(0)
-def test_crash_4mb_uncompressed():
-    run_test('test_crash_4mb_uncompressed', 4 * 1024 * 1024, compressed=False)
+async def _test_crash_4mb_uncompressed(session):
+    await run_test('test_crash_4mb_uncompressed', session, 4 * 1024 * 1024, compressed=False)
 
 
 @scenario(0)
-def test_crash_20mb_uncompressed():
-    run_test('test_crash_20mb_uncompressed', 20 * 1024 * 1024,
-             compressed=False)
+async def _test_crash_20mb_uncompressed(session):
+    await run_test('test_crash_20mb_uncompressed', session, 20 * 1024 * 1024, compressed=False)
 
 
-@scenario(0)
-def test_crash_400k_uncompressed_multiple_dumps():
-    run_test('test_crash_400k_uncompressed_multiple_dumps', 400 * 1024,
+@scenario(25)
+async def _test_crash_400k_uncompressed_multiple_dumps(session):
+    await run_test('test_crash_400k_uncompressed_multiple_dumps', session, 400 * 1024,
              dump_names=[
                  'upload_file_minidump',
                  'upload_file_minidump_browser',

--- a/loadtest.py
+++ b/loadtest.py
@@ -1,7 +1,6 @@
 import os
 import sys; sys.path.append('.')
 
-import aiohttp
 from molotov import scenario
 
 import utils

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 six
-requests
-https://github.com/tarekziade/molotov/archive/284e47562e.zip
+aiohttp
+# This is after the 0.3 release, but before a 0.4 release
+https://github.com/loads/molotov/archive/550fc9e.tar.gz


### PR DESCRIPTION
This overhauls the load tests to work with molotov 0.3 and aiohttp.

The compressed tests don't work and thus the scenarios have a different weighting.

I'm puzzled by what's going on with the compressed tests. What happens now is that they hang during the `session.post` call indefinitely. It's possible the payload is in the wrong form and so when whatever machinery in aiohttp goes to post the data, it's reading and blocks on that or something like that. I'm not sure what's going on, yet.

The docs have this:

http://aiohttp.readthedocs.io/en/stable/client.html#uploading-pre-compressed-data

That matches our scenario, except we're using gzip compression. Maybe aiohttp is doing something fancy that is surprised by gzip compression? Maybe the payload is not the right type?